### PR TITLE
Fix transaction check - transactions in wallet can be coinbase tx's too

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -306,7 +306,8 @@ ReadKeyValue(CWallet* pwallet, CDataStream& ssKey, CDataStream& ssValue,
             CWalletTx wtx;
             ssValue >> wtx;
             CValidationState state;
-            if (!(CheckRegularTransaction(wtx, state) && (wtx.GetId() == hash) && state.IsValid()))
+            bool isValid = wtx.IsCoinBase() ? CheckCoinbase(wtx, state) : CheckRegularTransaction(wtx, state);
+            if (wtx.GetId() != hash || !isValid)
                 return false;
 
             // Undo serialize changes in 31600


### PR DESCRIPTION
Now that regular and coinbase transaction validation checks have been separated, we must perform both during wallet reading. This PR re-introduces the coinbase tx check.