### PR TITLE
Extend inv capability in order to support extension blocks

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -84,6 +84,7 @@ BITCOIN_TESTS =\
   test/DoS_tests.cpp \
   test/getarg_tests.cpp \
   test/hash_tests.cpp \
+  test/inv_tests.cpp \
   test/key_tests.cpp \
   test/limitedmap_tests.cpp \
   test/dbwrapper_tests.cpp \

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -135,8 +135,7 @@ bool operator<(const CInv &a, const CInv &b) {
 
 std::string CInv::GetCommand() const {
     std::string cmd;
-    int masked = type & MSG_TYPE_MASK;
-    switch (masked) {
+    switch (GetKind()) {
         case MSG_TX:
             return cmd.append(NetMsgType::TX);
         case MSG_BLOCK:

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -310,7 +310,8 @@ public:
 };
 
 /** getdata message type flags */
-const uint32_t MSG_TYPE_MASK = 0xffffffff >> 2;
+const uint32_t MSG_EXT_FLAG = 1 << 29;
+const uint32_t MSG_TYPE_MASK = 0xffffffff >> 3;
 
 /** getdata / inv message types.
  * These numbers are defined by the protocol. When adding a new value, be sure
@@ -325,6 +326,10 @@ enum GetDataMsg {
     MSG_FILTERED_BLOCK = 3,
     //!< Defined in BIP152
     MSG_CMPCT_BLOCK = 4,
+
+    //!< Extension block
+    MSG_EXT_TX = MSG_TX | MSG_EXT_FLAG,
+    MSG_EXT_BLOCK = MSG_BLOCK | MSG_EXT_FLAG,
 };
 
 /** inv message data */
@@ -345,6 +350,19 @@ public:
 
     std::string GetCommand() const;
     std::string ToString() const;
+
+    uint32_t GetKind() const { return type & MSG_TYPE_MASK; }
+
+    bool IsTx() const {
+        auto k = GetKind();
+        return k == MSG_TX;
+    }
+
+    bool IsSomeBlock() const {
+        auto k = GetKind();
+        return k == MSG_BLOCK || k == MSG_FILTERED_BLOCK ||
+               k == MSG_CMPCT_BLOCK;
+    }
 
     // TODO: make private (improves encapsulation)
 public:

--- a/src/test/inv_tests.cpp
+++ b/src/test/inv_tests.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 Amaury SÉCHET
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "protocol.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_SUITE(inv_tests)
+
+static void CheckType(int type, int expected, bool IsTx, bool IsBlock) {
+    CInv inv(type, uint256());
+    BOOST_CHECK_EQUAL(inv.GetKind(), expected);
+    BOOST_CHECK_EQUAL(inv.IsTx(), IsTx);
+    BOOST_CHECK_EQUAL(inv.IsSomeBlock(), IsBlock);
+}
+
+/* Validate various inv facilities. */
+BOOST_AUTO_TEST_CASE(validate_kind) {
+    CheckType(GetDataMsg::UNDEFINED, GetDataMsg::UNDEFINED, false, false);
+    CheckType(GetDataMsg::MSG_TX, GetDataMsg::MSG_TX, true, false);
+    CheckType(GetDataMsg::MSG_BLOCK, GetDataMsg::MSG_BLOCK, false, true);
+    CheckType(GetDataMsg::MSG_FILTERED_BLOCK, GetDataMsg::MSG_FILTERED_BLOCK,
+              false, true);
+    CheckType(GetDataMsg::MSG_CMPCT_BLOCK, GetDataMsg::MSG_CMPCT_BLOCK, false,
+              true);
+    CheckType(GetDataMsg::MSG_EXT_TX, GetDataMsg::MSG_TX, true, false);
+    CheckType(GetDataMsg::MSG_EXT_BLOCK, GetDataMsg::MSG_BLOCK, false, true);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This extends the inv class to take into account the extension block flag.

Also add a set of tests for the CInv class.