### PR TITLE
Split the part that read the blockundo data from disk so the actual u…

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -122,6 +122,7 @@ BITCOIN_TESTS =\
   test/txvalidationcache_tests.cpp \
   test/versionbits_tests.cpp \
   test/uint256_tests.cpp \
+  test/undo_tests.cpp \
   test/univalue_tests.cpp \
   test/util_tests.cpp
 

--- a/src/test/undo_tests.cpp
+++ b/src/test/undo_tests.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2017 Amaury SÉCHET
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "undo.h"
+#include "chainparams.h"
+#include "consensus/validation.h"
+#include "validation.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(undo_tests, BasicTestingSetup)
+
+static void UpdateUTXOSet(const CBlock &block, CCoinsViewCache &view,
+                          CBlockUndo &blockundo,
+                          const CChainParams &chainparams, uint32_t nHeight) {
+    CValidationState state;
+
+    auto &coinbaseTx = *block.vtx[0];
+    UpdateCoins(coinbaseTx, view, nHeight);
+
+    for (size_t i = 1; i < block.vtx.size(); i++) {
+        auto &tx = *block.vtx[1];
+
+        blockundo.vtxundo.push_back(CTxUndo());
+        UpdateCoins(tx, view, blockundo.vtxundo.back(), nHeight);
+    }
+
+    view.SetBestBlock(block.GetHash());
+}
+
+static void UndoBlock(const CBlock &block, CCoinsViewCache &view,
+                      const CBlockUndo &blockundo,
+                      const CChainParams &chainparams, uint32_t nHeight) {
+    CValidationState state;
+
+    CBlockIndex pindex;
+    pindex.nHeight = nHeight;
+
+    ApplyBlockUndo(block, state, &pindex, view, blockundo);
+}
+
+static bool HashSpendableCoin(const CCoinsViewCache &view, uint256 txid) {
+    const CCoins *coins = view.AccessCoins(txid);
+    return coins != nullptr && !coins->IsPruned();
+}
+
+BOOST_AUTO_TEST_CASE(connect_utxo_extblock) {
+    SelectParams(CBaseChainParams::MAIN);
+    const CChainParams &chainparams = Params();
+
+    CBlock block;
+    CMutableTransaction tx;
+
+    CCoinsView coinsDummy;
+    CCoinsViewCache view(&coinsDummy);
+
+    block.hashPrevBlock = GetRandHash();
+    view.SetBestBlock(block.hashPrevBlock);
+
+    // Create a block with coinbase and resolution transaction.
+    tx.vin.resize(1);
+    tx.vin[0].scriptSig.resize(10);
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 42;
+    auto coinbaseTx = CTransaction(tx);
+
+    block.vtx.resize(2);
+    block.vtx[0] = MakeTransactionRef(tx);
+
+    tx.vout[0].scriptPubKey = CScript() << OP_TRUE;
+    tx.vin[0].prevout.hash = GetRandHash();
+    tx.vin[0].prevout.n = 0;
+    tx.vin[0].nSequence = CTxIn::SEQUENCE_FINAL;
+    tx.vin[0].scriptSig.resize(0);
+    tx.nVersion = 2;
+
+    auto prevTx0 = CTransaction(tx);
+    view.ModifyNewCoins(prevTx0.GetId(), prevTx0.IsCoinBase())
+        ->FromTx(prevTx0, 100);
+
+    tx.vin[0].prevout.hash = prevTx0.GetId();
+    auto tx0 = CTransaction(tx);
+    block.vtx[1] = MakeTransactionRef(tx0);
+
+    // Now update the UTXO set.
+    CBlockUndo blockundo;
+    UpdateUTXOSet(block, view, blockundo, chainparams, 123456);
+
+    BOOST_CHECK(view.GetBestBlock() == block.GetHash());
+    BOOST_CHECK(HashSpendableCoin(view, coinbaseTx.GetId()));
+    BOOST_CHECK(HashSpendableCoin(view, tx0.GetId()));
+    BOOST_CHECK(!HashSpendableCoin(view, prevTx0.GetId()));
+
+    UndoBlock(block, view, blockundo, chainparams, 123456);
+
+    BOOST_CHECK(view.GetBestBlock() == block.hashPrevBlock);
+    BOOST_CHECK(!HashSpendableCoin(view, coinbaseTx.GetId()));
+    BOOST_CHECK(!HashSpendableCoin(view, tx0.GetId()));
+    BOOST_CHECK(HashSpendableCoin(view, prevTx0.GetId()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/undo.h
+++ b/src/undo.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2017 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,6 +10,11 @@
 #include "compressor.h"
 #include "primitives/transaction.h"
 #include "serialize.h"
+
+class CBlock;
+class CBlockIndex;
+class CCoinsViewCache;
+class CValidationState;
 
 /** Undo information for a CTxIn
  *
@@ -76,5 +82,15 @@ public:
         READWRITE(vtxundo);
     }
 };
+
+/** Apply the undo operation of a CTxInUndo to the given chain state. */
+bool ApplyTxInUndo(const CTxInUndo &undo, CCoinsViewCache &view,
+                   const COutPoint &out);
+
+/** Undo a block from the block and the undoblock data.
+ * See DisconnectBlock for more details. */
+bool ApplyBlockUndo(const CBlock &block, CValidationState &state,
+                    const CBlockIndex *pindex, CCoinsViewCache &coins,
+                    const CBlockUndo &blockUndo, bool *pfClean = nullptr);
 
 #endif // BITCOIN_UNDO_H

--- a/src/validation.h
+++ b/src/validation.h
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
+// Copyright (c) 2017 The Bitcoin developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -40,6 +41,7 @@ class CInv;
 class CConnman;
 class CScriptCheck;
 class CTxMemPool;
+class CTxUndo;
 class CValidationInterface;
 class CValidationState;
 struct ChainTxData;
@@ -436,6 +438,8 @@ bool CheckInputs(const CTransaction &tx, CValidationState &state,
 
 /** Apply the effects of this transaction on the UTXO set represented by view */
 void UpdateCoins(const CTransaction &tx, CCoinsViewCache &inputs, int nHeight);
+void UpdateCoins(const CTransaction &tx, CCoinsViewCache &inputs,
+                 CTxUndo &txundo, int nHeight);
 
 /** Transaction validation functions */
 
@@ -590,7 +594,7 @@ bool ConnectBlock(const CBlock &block, CValidationState &state,
  * any case, coins may be modified. */
 bool DisconnectBlock(const CBlock &block, CValidationState &state,
                      const CBlockIndex *pindex, CCoinsViewCache &coins,
-                     bool *pfClean = NULL);
+                     bool *pfClean = nullptr);
 
 /** Check a block is completely valid from start to finish (only works on top of
  * our current best block, with cs_main held) */


### PR DESCRIPTION
The first read the undo data from disk and the second does the undo. This ensure we don't depend on the state of the filesystem to undo and makes is easier to unit test. The patch also includes a basic unit test for undo.