### PR TITLE
Convert user-visible Bitcoin Core => Bitcoin ABC.

### DIFF
--- a/contrib/debian/bitcoin-qt.desktop
+++ b/contrib/debian/bitcoin-qt.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Encoding=UTF-8
-Name=Bitcoin Core
+Name=Bitcoin ABC
 Comment=Connect to the Bitcoin P2P Network
 Comment[de]=Verbinde mit dem Bitcoin peer-to-peer Netzwerk
 Comment[fr]=Bitcoin, monnaie virtuelle cryptographique pair à pair

--- a/contrib/init/bitcoind.conf
+++ b/contrib/init/bitcoind.conf
@@ -1,4 +1,4 @@
-description "Bitcoin Core Daemon"
+description "Bitcoin ABC Daemon"
 
 start on runlevel [2345]
 stop on starting rc RUNLEVEL=[016]

--- a/contrib/init/bitcoind.openrc
+++ b/contrib/init/bitcoind.openrc
@@ -18,7 +18,7 @@ BITCOIND_BIN=${BITCOIND_BIN:-/usr/bin/bitcoind}
 BITCOIND_NICE=${BITCOIND_NICE:-${NICELEVEL:-0}}
 BITCOIND_OPTS="${BITCOIND_OPTS:-${BITCOIN_OPTS}}"
 
-name="Bitcoin Core Daemon"
+name="Bitcoin ABC Daemon"
 description="Bitcoin cryptocurrency P2P network daemon"
 
 command="/usr/bin/bitcoind"


### PR DESCRIPTION
This fixes the tooltip in Unity launcher.