### PR TITLE
Change denomination from BCC to BC

### DIFF
--- a/src/amount.cpp
+++ b/src/amount.cpp
@@ -7,7 +7,7 @@
 
 #include "tinyformat.h"
 
-const std::string CURRENCY_UNIT = "BCC";
+const std::string CURRENCY_UNIT = "BC";
 
 CFeeRate::CFeeRate(const CAmount &nFeePaid, size_t nBytes_) {
     assert(nBytes_ <= uint64_t(std::numeric_limits<int64_t>::max()));

--- a/src/amount.h
+++ b/src/amount.h
@@ -23,7 +23,7 @@ extern const std::string CURRENCY_UNIT;
  * No amount larger than this (in satoshi) is valid.
  *
  * Note that this constant is *not* the total money supply, which in Bitcoin
- * currently happens to be less than 21,000,000 BCC for various reasons, but
+ * currently happens to be less than 21,000,000 BC for various reasons, but
  * rather a sanity check. As this sanity check is used by consensus-critical
  * validation code, the exact value of the MAX_MONEY constant is consensus
  * critical; in unusual circumstances like a(nother) overflow bug that allowed

--- a/src/coins.h
+++ b/src/coins.h
@@ -97,7 +97,7 @@ public:
  *    - code = 4 (vout[1] is not spent, and 0 non-zero bytes of bitvector follow)
  *    - unspentness bitvector: as 0 non-zero bytes follow, it has length 0
  *    - vout[1]: 835800816115944e077fe7c803cfa57f29b36bf87c1d35
- *               * 8358: compact amount representation for 60000000000 (600 BCC)
+ *               * 8358: compact amount representation for 60000000000 (600 BC)
  *               * 00: special txout type pay-to-pubkey-hash
  *               * 816115944e077fe7c803cfa57f29b36bf87c1d35: address uint160
  *    - height = 203998
@@ -113,11 +113,11 @@ public:
  *                2 (1, +1 because both bit 1 and bit 2 are unset) non-zero bitvector bytes follow)
  *  - unspentness bitvector: bits 2 (0x04) and 14 (0x4000) are set, so vout[2+2] and vout[14+2] are unspent
  *  - vout[4]: 86ef97d5790061b01caab50f1b8e9c50a5057eb43c2d9563a4ee
- *             * 86ef97d579: compact amount representation for 234925952 (2.35 BCC)
+ *             * 86ef97d579: compact amount representation for 234925952 (2.35 BC)
  *             * 00: special txout type pay-to-pubkey-hash
  *             * 61b01caab50f1b8e9c50a5057eb43c2d9563a4ee: address uint160
  *  - vout[16]: bbd123008c988f1a4a4de2161e0f50aac7f17e7f9555caa4
- *              * bbd123: compact amount representation for 110397 (0.001 BCC)
+ *              * bbd123: compact amount representation for 110397 (0.001 BC)
  *              * 00: special txout type pay-to-pubkey-hash
  *              * 8c988f1a4a4de2161e0f50aac7f17e7f9555caa4: address uint160
  *  - height = 120891

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -378,7 +378,7 @@ void CBlockPolicyEstimator::processTransaction(const CTxMemPoolEntry &entry,
     }
     trackedTxs++;
 
-    // Feerates are stored and reported as BCC-per-kb:
+    // Feerates are stored and reported as BC-per-kb:
     CFeeRate feeRate(entry.GetFee(), entry.GetTxSize());
 
     mapMemPoolTxs[txid].blockHeight = txHeight;
@@ -406,7 +406,7 @@ bool CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight,
         return false;
     }
 
-    // Feerates are stored and reported as BCC-per-kb:
+    // Feerates are stored and reported as BC-per-kb:
     CFeeRate feeRate(entry->GetFee(), entry->GetTxSize());
 
     feeStats.Record(blocksToConfirm, (double)feeRate.GetFeePerK());

--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -23,7 +23,7 @@ class AmountSpinBox : public QAbstractSpinBox {
 
 public:
     explicit AmountSpinBox(QWidget *parent)
-        : QAbstractSpinBox(parent), currentUnit(BitcoinUnits::BCC),
+        : QAbstractSpinBox(parent), currentUnit(BitcoinUnits::BC),
           singleStep(100000 /* satoshis */) {
         setAlignment(Qt::AlignRight);
 
@@ -89,7 +89,7 @@ public:
             const QFontMetrics fm(fontMetrics());
             int h = lineEdit()->minimumSizeHint().height();
             int w = fm.width(BitcoinUnits::format(
-                BitcoinUnits::BCC, BitcoinUnits::maxMoney(), false,
+                BitcoinUnits::BC, BitcoinUnits::maxMoney(), false,
                 BitcoinUnits::separatorAlways));
             // Cursor blinking space.
             w += 2;

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -13,17 +13,17 @@ BitcoinUnits::BitcoinUnits(QObject *parent)
 
 QList<BitcoinUnits::Unit> BitcoinUnits::availableUnits() {
     QList<BitcoinUnits::Unit> unitlist;
-    unitlist.append(BCC);
-    unitlist.append(mBCC);
-    unitlist.append(uBCC);
+    unitlist.append(BC);
+    unitlist.append(mBC);
+    unitlist.append(uBC);
     return unitlist;
 }
 
 bool BitcoinUnits::valid(int unit) {
     switch (unit) {
-        case BCC:
-        case mBCC:
-        case uBCC:
+        case BC:
+        case mBC:
+        case uBC:
             return true;
         default:
             return false;
@@ -32,12 +32,12 @@ bool BitcoinUnits::valid(int unit) {
 
 QString BitcoinUnits::name(int unit) {
     switch (unit) {
-        case BCC:
-            return QString("BCC");
-        case mBCC:
-            return QString("mBCC");
-        case uBCC:
-            return QString::fromUtf8("μBCC");
+        case BC:
+            return QString("BC");
+        case mBC:
+            return QString("mBC");
+        case uBC:
+            return QString::fromUtf8("μBC");
         default:
             return QString("???");
     }
@@ -45,11 +45,11 @@ QString BitcoinUnits::name(int unit) {
 
 QString BitcoinUnits::description(int unit) {
     switch (unit) {
-        case BCC:
+        case BC:
             return QString("Bitcoins");
-        case mBCC:
+        case mBC:
             return QString("Milli-Bitcoins (1 / 1" THIN_SP_UTF8 "000)");
-        case uBCC:
+        case uBC:
             return QString("Micro-Bitcoins (1 / 1" THIN_SP_UTF8
                            "000" THIN_SP_UTF8 "000)");
         default:
@@ -59,11 +59,11 @@ QString BitcoinUnits::description(int unit) {
 
 qint64 BitcoinUnits::factor(int unit) {
     switch (unit) {
-        case BCC:
+        case BC:
             return 100000000;
-        case mBCC:
+        case mBC:
             return 100000;
-        case uBCC:
+        case uBC:
             return 100;
         default:
             return 100000000;
@@ -72,11 +72,11 @@ qint64 BitcoinUnits::factor(int unit) {
 
 int BitcoinUnits::decimals(int unit) {
     switch (unit) {
-        case BCC:
+        case BC:
             return 8;
-        case mBCC:
+        case mBC:
             return 5;
-        case uBCC:
+        case uBC:
             return 2;
         default:
             return 0;

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -56,7 +56,7 @@ public:
      * @note Source: https://en.bitcoin.it/wiki/Units.
      * Please add only sensible ones.
      */
-    enum Unit { BCC, mBCC, uBCC };
+    enum Unit { BC, mBC, uBC };
 
     enum SeparatorStyle { separatorNever, separatorStandard, separatorAlways };
 

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -584,7 +584,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog *dialog) {
     }
 
     // actually update labels
-    int nDisplayUnit = BitcoinUnits::BCC;
+    int nDisplayUnit = BitcoinUnits::BC;
     if (model && model->getOptionsModel()) {
         nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
     }

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -132,7 +132,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BCC</string>
+          <string notr="true">0.00 BC</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -212,7 +212,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BCC</string>
+          <string notr="true">0.00 BC</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -257,7 +257,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BCC</string>
+          <string notr="true">0.00 BC</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -292,7 +292,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BCC</string>
+          <string notr="true">0.00 BC</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/forms/overviewpage.ui
+++ b/src/qt/forms/overviewpage.ui
@@ -129,7 +129,7 @@
                <string>Unconfirmed transactions to watch-only addresses</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BCC</string>
+               <string notr="true">0.000 000 00 BC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -154,7 +154,7 @@
                <string>Total of transactions that have yet to be confirmed, and do not yet count toward the spendable balance</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BCC</string>
+               <string notr="true">0.000 000 00 BC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -179,7 +179,7 @@
                <string>Mined balance in watch-only addresses that has not yet matured</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BCC</string>
+               <string notr="true">0.000 000 00 BC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -237,7 +237,7 @@
                <string>Mined balance that has not yet matured</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BCC</string>
+               <string notr="true">0.000 000 00 BC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -282,7 +282,7 @@
                <string>Your current total balance</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BCC</string>
+               <string notr="true">0.000 000 00 BC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -307,7 +307,7 @@
                <string>Current total balance in watch-only addresses</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BCC</string>
+               <string notr="true">0.000 000 00 BC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -349,7 +349,7 @@
                <string>Your current spendable balance</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BCC</string>
+               <string notr="true">0.000 000 00 BC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -374,7 +374,7 @@
                <string>Your current balance in watch-only addresses</string>
               </property>
               <property name="text">
-               <string notr="true">0.000 000 00 BCC</string>
+               <string notr="true">0.000 000 00 BC</string>
               </property>
               <property name="alignment">
                <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/src/qt/forms/sendcoinsdialog.ui
+++ b/src/qt/forms/sendcoinsdialog.ui
@@ -324,7 +324,7 @@
                   <enum>Qt::ActionsContextMenu</enum>
                  </property>
                  <property name="text">
-                  <string notr="true">0.00 BCC</string>
+                  <string notr="true">0.00 BC</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -404,7 +404,7 @@
                   <enum>Qt::ActionsContextMenu</enum>
                  </property>
                  <property name="text">
-                  <string notr="true">0.00 BCC</string>
+                  <string notr="true">0.00 BC</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -455,7 +455,7 @@
                   <enum>Qt::ActionsContextMenu</enum>
                  </property>
                  <property name="text">
-                  <string notr="true">0.00 BCC</string>
+                  <string notr="true">0.00 BC</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -484,7 +484,7 @@
                   <enum>Qt::ActionsContextMenu</enum>
                  </property>
                  <property name="text">
-                  <string notr="true">0.00 BCC</string>
+                  <string notr="true">0.00 BC</string>
                  </property>
                  <property name="textInteractionFlags">
                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -1290,7 +1290,7 @@
           <cursorShape>IBeamCursor</cursorShape>
          </property>
          <property name="text">
-          <string notr="true">123.456 BCC</string>
+          <string notr="true">123.456 BC</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -185,7 +185,7 @@ bool parseBitcoinURI(const QUrl &uri, SendCoinsRecipient *out) {
             fShouldReturnFalse = false;
         } else if (i->first == "amount") {
             if (!i->second.isEmpty()) {
-                if (!BitcoinUnits::parse(BitcoinUnits::BCC, i->second,
+                if (!BitcoinUnits::parse(BitcoinUnits::BC, i->second,
                                          &rv.amount)) {
                     return false;
                 }
@@ -223,7 +223,7 @@ QString formatBitcoinURI(const SendCoinsRecipient &info) {
     if (info.amount) {
         ret +=
             QString("?amount=%1")
-                .arg(BitcoinUnits::format(BitcoinUnits::BCC, info.amount, false,
+                .arg(BitcoinUnits::format(BitcoinUnits::BC, info.amount, false,
                                           BitcoinUnits::separatorNever));
         paramCount++;
     }

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -74,7 +74,7 @@ void OptionsModel::Init(bool resetSettings) {
 
     // Display
     if (!settings.contains("nDisplayUnit")) {
-        settings.setValue("nDisplayUnit", BitcoinUnits::BCC);
+        settings.setValue("nDisplayUnit", BitcoinUnits::BC);
     }
     nDisplayUnit = settings.value("nDisplayUnit").toInt();
 

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -26,7 +26,7 @@ class TxViewDelegate : public QAbstractItemDelegate {
 public:
     TxViewDelegate(const PlatformStyle *_platformStyle,
                    QObject *parent = nullptr)
-        : QAbstractItemDelegate(parent), unit(BitcoinUnits::BCC),
+        : QAbstractItemDelegate(parent), unit(BitcoinUnits::BC),
           platformStyle(_platformStyle) {}
 
     inline void paint(QPainter *painter, const QStyleOptionViewItem &option,
@@ -264,7 +264,7 @@ void OverviewPage::setWalletModel(WalletModel *model) {
                 SLOT(updateWatchOnlyLabels(bool)));
     }
 
-    // update the display unit, to not use the default ("BCC")
+    // update the display unit, to not use the default ("BC")
     updateDisplayUnit();
 }
 

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -107,7 +107,7 @@ void SendCoinsEntry::clear() {
     ui->memoTextLabel_s->clear();
     ui->payAmount_s->clear();
 
-    // update the display unit, to not use the default ("BCC")
+    // update the display unit, to not use the default ("BC")
     updateDisplayUnit();
 }
 

--- a/src/qt/test/paymentrequestdata.h
+++ b/src/qt/test/paymentrequestdata.h
@@ -427,7 +427,7 @@ d2hj739GDLz0b5KuJ2SG6VknMRQM976w/m2qlq0ccVGaaZ2zMIGfpzL3p6adwx/5\
 ";
 
 //
-// Payment request with amount overflow (amount is set to 21000001 BCC)
+// Payment request with amount overflow (amount is set to 21000001 BC)
 //
 const char *paymentrequest5_cert2_BASE64 = "\
 Egt4NTA5K3NoYTI1NhrQBArNBDCCAkkwggExoAMCAQICAQEwDQYJKoZIhvcNAQEL\

--- a/src/qt/test/paymentservertests.cpp
+++ b/src/qt/test/paymentservertests.cpp
@@ -197,7 +197,7 @@ void PaymentServerTests::paymentServerTests() {
     // compares 50001 <= BIP70_MAX_PAYMENTREQUEST_SIZE == false
     QCOMPARE(PaymentServer::verifySize(tempFile.size()), false);
 
-    // Payment request with amount overflow (amount is set to 21000001 BCC):
+    // Payment request with amount overflow (amount is set to 21000001 BC):
     data = DecodeBase64(paymentrequest5_cert2_BASE64);
     byteArray = QByteArray((const char *)&data[0], data.size());
     r.paymentRequest.parse(byteArray);

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -296,7 +296,7 @@ static UniValue getmininginfo(const Config &config,
     return obj;
 }
 
-// NOTE: Unlike wallet RPC (which use BCC values), mining RPCs follow GBT (BIP
+// NOTE: Unlike wallet RPC (which use BC values), mining RPCs follow GBT (BIP
 // 22) in using satoshi amounts
 static UniValue prioritisetransaction(const Config &config,
                                       const JSONRPCRequest &request) {
@@ -998,7 +998,7 @@ static UniValue estimatesmartfee(const Config &config,
             "\nResult:\n"
             "{\n"
             "  \"feerate\" : x.x,     (numeric) estimate fee-per-kilobyte (in "
-            "BCC)\n"
+            "BC)\n"
             "  \"blocks\" : n         (numeric) block number where estimate "
             "was found\n"
             "}\n"

--- a/src/test/compress_tests.cpp
+++ b/src/test/compress_tests.cpp
@@ -17,10 +17,10 @@
 #define NUM_MULTIPLES_CENT 10000
 
 // amounts 1 .. 10000
-#define NUM_MULTIPLES_1BCC 10000
+#define NUM_MULTIPLES_1BC 10000
 
 // amounts 50 .. 21000000
-#define NUM_MULTIPLES_50BCC 420000
+#define NUM_MULTIPLES_50BC 420000
 
 BOOST_FIXTURE_TEST_SUITE(compress_tests, BasicTestingSetup)
 
@@ -55,11 +55,11 @@ BOOST_AUTO_TEST_CASE(compress_amounts) {
         BOOST_CHECK(TestEncode(i * CENT));
     }
 
-    for (uint64_t i = 1; i <= NUM_MULTIPLES_1BCC; i++) {
+    for (uint64_t i = 1; i <= NUM_MULTIPLES_1BC; i++) {
         BOOST_CHECK(TestEncode(i * COIN));
     }
 
-    for (uint64_t i = 1; i <= NUM_MULTIPLES_50BCC; i++) {
+    for (uint64_t i = 1; i <= NUM_MULTIPLES_50BC; i++) {
         BOOST_CHECK(TestEncode(i * 50 * COIN));
     }
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -168,7 +168,7 @@ void TestPackageSelection(const CChainParams &chainparams, CScript scriptPubKey,
     tx.vin[0].prevout.hash = txFirst[2]->GetId();
     tx.vout.resize(2);
     tx.vout[0].nValue = 5000000000LL - 100000000;
-    // 1BCC output.
+    // 1BC output.
     tx.vout[1].nValue = 100000000;
     uint256 hashFreeTx2 = tx.GetId();
     mempool.addUnchecked(hashFreeTx2,

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(json_parse_errors) {
     // Invalid, trailing garbage
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("1.0sds"), std::runtime_error);
     BOOST_CHECK_THROW(ParseNonRFCJSONValue("1.0]"), std::runtime_error);
-    // BCC addresses should fail parsing
+    // BC addresses should fail parsing
     BOOST_CHECK_THROW(
         ParseNonRFCJSONValue("175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W"),
         std::runtime_error);

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -224,13 +224,13 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests) {
         add_coin(4 * COIN);
         BOOST_CHECK(wallet.SelectCoinsMinConf(95 * CENT, 1, 1, 0, vCoins,
                                               setCoinsRet, nValueRet));
-        // we should get 1 BCC in 1 coin
+        // we should get 1 BC in 1 coin
         BOOST_CHECK_EQUAL(nValueRet, 1 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 
         BOOST_CHECK(wallet.SelectCoinsMinConf(195 * CENT, 1, 1, 0, vCoins,
                                               setCoinsRet, nValueRet));
-        // we should get 2 BCC in 1 coin
+        // we should get 2 BC in 1 coin
         BOOST_CHECK_EQUAL(nValueRet, 2 * COIN);
         BOOST_CHECK_EQUAL(setCoinsRet.size(), 1U);
 


### PR DESCRIPTION
There has been lots of discussions/astroturfing that BCC is already taken. As it appears, no major currency/ticker is using BC. BC fits with *Bitcoin *Cash, but also in the event that Bitcoin Cash gets majority hashrate it could also mean *Bit*Coin.