### PR TITLE
Update default datacarriersize to 220 byte

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -27,7 +27,7 @@ public:
 };
 
 //!< bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
-static const unsigned int MAX_OP_RETURN_RELAY = 83;
+static const unsigned int MAX_OP_RETURN_RELAY = 223;
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -567,20 +567,26 @@ BOOST_AUTO_TEST_CASE(test_IsStandard) {
     // MAX_OP_RETURN_RELAY-byte TX_NULL_DATA (standard)
     t.vout[0].scriptPubKey =
         CScript() << OP_RETURN
-                  << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909"
-                              "a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548"
-                              "271967f1a67130b7105cd6a828e03909a67962e0ea1f61de"
-                              "b649f6bc3f4cef38");
+                  << ParseHex("646578784062697477617463682e636f2092c558ed52c56d"
+            "8dd14ca76226bc936a84820d898443873eb03d8854b21fa3952b99a2981873e745"
+            "09281730d78a21786d34a38bd1ebab822fad42278f7f4420db6ab1fd2b6826148d"
+            "4f73bb41ec2d40a6d5793d66e17074a0c56a8a7df21062308f483dd6e38d53609d"
+            "350038df0a1b2a9ac8332016e0b904f66880dd010881c4e8074cce8e4ad6c77cb3"
+            "460e01bf0e7e811b5f945f83732ba6677520a893d75d9a966cb8f85dc301656b16"
+            "35c631f5d00d4adf73f2dd112ca75cf19754651909becfbe65aed13afb2ab8");
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
     BOOST_CHECK(IsStandardTx(t, reason));
 
     // MAX_OP_RETURN_RELAY+1-byte TX_NULL_DATA (non-standard)
     t.vout[0].scriptPubKey =
         CScript() << OP_RETURN
-                  << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909"
-                              "a67962e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548"
-                              "271967f1a67130b7105cd6a828e03909a67962e0ea1f61de"
-                              "b649f6bc3f4cef3800");
+                  << ParseHex("646578784062697477617463682e636f2092c558ed52c56d"
+            "8dd14ca76226bc936a84820d898443873eb03d8854b21fa3952b99a2981873e745"
+            "09281730d78a21786d34a38bd1ebab822fad42278f7f4420db6ab1fd2b6826148d"
+            "4f73bb41ec2d40a6d5793d66e17074a0c56a8a7df21062308f483dd6e38d53609d"
+            "350038df0a1b2a9ac8332016e0b904f66880dd010881c4e8074cce8e4ad6c77cb3"
+            "460e01bf0e7e811b5f945f83732ba6677520a893d75d9a966cb8f85dc301656b16"
+            "35c631f5d00d4adf73f2dd112ca75cf19754651909becfbe65aed13afb2ab800");
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY + 1, t.vout[0].scriptPubKey.size());
     BOOST_CHECK(!IsStandardTx(t, reason));
 


### PR DESCRIPTION
To disincentivize the use of other and more harmful methods to embed data into the chain, in particular via P2SH, the default datacarriersize is raised from 80 byte to 220 byte, so it becomes the "cheapest" way of embedding data into the chain.

The following graph shows the relation between transaction sizes and payload sizes:

![](http://i.imgur.com/VAGZWBK.png)

Embedding data with bare-multisig and P2SH can be cheaper in terms of effective transaction size, compared to OP_RETURN with a payload limit of 80 byte. Both methods of embedding data, via bare-multisig and P2SH, are heavily used by the major two meta-protocols on top of Bitcoin: Omni and Counterparty (see [here](https://github.com/OmniLayer/spec#class-b-transactions-also-known-as-the-multisig-method) and [here](https://github.com/CounterpartyXCP/cips/blob/master/cip-0006.md)).

This pull request updates the default datacarriersize to 220 byte and it's related tests.