### PR TITLE
Make "maximum length of incoming protocol messages" comment match the code.

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -56,7 +56,7 @@ static const int FEELER_INTERVAL = 120;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
-/** Maximum length of incoming protocol messages (no message over 4 MB is
+/** Maximum length of incoming protocol messages (no message over 32 MB is
  * currently acceptable). */
 static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 32 * 1000 * 1000;
 /** Maximum length of strSubVer in `version` message */


### PR DESCRIPTION
There have been misunderstandings in private conversations that the maximum protocol message size is 4MB because that's what the comment in net.h says, meaning that an 8MB block cannot be accepted. This should probably be changed to avoid confusion. This limit was changed in https://github.com/Bitcoin-ABC/bitcoin-abc/commit/d757be14a738750d2056817ec5755e490ff1add3.

This is a very minor pull request so feel free to make the change in a different merge.