### PR TITLE
Change the type of BlockStatus to unsigned int

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -106,7 +106,7 @@ struct CDiskBlockPos {
     }
 };
 
-enum BlockStatus : uint32_t {
+enum BlockStatus : unsigned int {
     //! Unused.
     BLOCK_VALID_UNKNOWN = 0,
 


### PR DESCRIPTION
1. The type used when using BlockStatus is unsigned int
2. The 16bits range is sufficient to use
3. unsigned int is whatever unsigned integer the compiler likes best