### PR TITLE
Put back inadvertently removed copyright notices

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) 2009-2015 Bitcoin Developers
 Copyright (c) 2009-2017 The Bitcoin Core developers
 Copyright (c) 2017 The Bitcoin ABC developers
 


### PR DESCRIPTION
I am an Open Source licensing compliance specialist. I was alerted to the issue here: https://github.com/Bitcoin-ABC/bitcoin-abc/issues/85

I looked into it and could find nothing in regards to their claims that would appear to be out of compliance with the MIT licensing.

However, I did find this. The terms of the MIT license say that the copyright notice that accompanies the license must be included in all copies of the software.

This commit by Satoshi removed his own copyright mark, which he is perfectly allowed to do since it's his. https://github.com/bitcoin/bitcoin/commit/fc73ad644f0b87b91f49b7f6f6b2348f78bdbbf4

However, this commit by Marius Kjærstad removes the stamp of each and every developer that was represented by that stamp. https://github.com/bitcoin/bitcoin/commit/3b00e7c231648cfe0c36c5f9f0c44953146c1a5b#diff-7116ef0705885343c9e1b2171a06be0e

It is conceivable that each and every developer that committed to the project prior 20 April 22, 2015 consented to removing their mark and replacing it with a more specific mark that could be interpreted to be a subset of the broader nomenclature or that those who did not consent had their code removed. I don't have access to the written agreements by these developers though, and I see no evidences that their contributions were removed, so I seriously doubt this was the case.

To avoid any claims by one of those developers, I recommend that we put their stamp back so that we are irrefutably in compliance with the license they contributed their code under.