### PR TITLE
Perform validation in a separate thread to message handling.

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -167,6 +167,7 @@ BITCOIN_CORE_H = \
   utilmoneystr.h \
   utiltime.h \
   validation.h \
+  validation_thread.h \
   validationinterface.h \
   versionbits.h \
   wallet/coincontrol.h \
@@ -231,6 +232,7 @@ libbitcoin_server_a_SOURCES = \
   txmempool.cpp \
   ui_interface.cpp \
   validation.cpp \
+  validation_thread.cpp \
   validationinterface.cpp \
   versionbits.cpp \
   $(BITCOIN_CORE_H)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1027,10 +1027,12 @@ void ThreadImport(const Config &config,
 
         // scan for better chains in the block chain database, that are not yet
         // connected in the active best chain
-        CValidationState state;
-        if (!ActivateBestChain(config, state)) {
-            LogPrintf("Failed to connect best block");
-            StartShutdown();
+        if (chainActive.Tip() == NULL) {
+            CValidationState state;
+            if (!ActivateBestChain(config, state)) {
+                LogPrintf("Failed to connect best block");
+                StartShutdown();
+            }
         }
 
         if (GetBoolArg("-stopafterblockimport", DEFAULT_STOPAFTERBLOCKIMPORT)) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2467,6 +2467,9 @@ bool CConnman::Start(CScheduler &scheduler, std::string &strNodeError,
                     std::function<void()>(
                         std::bind(&CConnman::ThreadMessageHandler, this)));
 
+    // Validate blocks
+    threadValidation = std::thread(&TraceThread<boost::function<void()> >, "validate", std::function<void()>(boost::bind(&CConnman::ThreadValidation, this)));
+
     // Dump network addresses
     scheduler.scheduleEvery(boost::bind(&CConnman::DumpData, this),
                             DUMP_ADDRESSES_INTERVAL);
@@ -2510,6 +2513,9 @@ void CConnman::Interrupt() {
 }
 
 void CConnman::Stop() {
+    if (threadValidation.joinable()) {
+        threadValidation.join();
+    }
     if (threadMessageHandler.joinable()) {
         threadMessageHandler.join();
     }

--- a/src/net.h
+++ b/src/net.h
@@ -301,6 +301,7 @@ private:
     void ProcessOneShot();
     void ThreadOpenConnections();
     void ThreadMessageHandler();
+    void ThreadValidation();
     void AcceptConnection(const ListenSocket &hListenSocket);
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
@@ -400,6 +401,8 @@ private:
 
     std::condition_variable condMsgProc;
     std::mutex mutexMsgProc;
+    std::condition_variable condValidation;
+    std::mutex mutexValidation;
     std::atomic<bool> flagInterruptMsgProc;
 
     CThreadInterrupt interruptNet;
@@ -409,6 +412,7 @@ private:
     std::thread threadOpenAddedConnections;
     std::thread threadOpenConnections;
     std::thread threadMessageHandler;
+    std::thread threadValidation;
 };
 extern std::unique_ptr<CConnman> g_connman;
 void Discover(boost::thread_group &threadGroup);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -972,6 +972,7 @@ void PeerLogicValidation::NewPoWValidBlock(
 void PeerLogicValidation::UpdatedBlockTip(const CBlockIndex *pindexNew,
                                           const CBlockIndex *pindexFork,
                                           bool fInitialDownload) {
+    // This will now often run in the validate thread rather than the message handler thread.
     const int nNewHeight = pindexNew->nHeight;
     connman->SetBestHeight(nNewHeight);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -119,6 +119,7 @@ bool fLogTimestamps = DEFAULT_LOGTIMESTAMPS;
 bool fLogTimeMicros = DEFAULT_LOGTIMEMICROS;
 bool fLogIPs = DEFAULT_LOGIPS;
 std::atomic<bool> fReopenDebugLog(false);
+std::atomic<bool> fActivatingChain(false);
 CTranslationInterface translationInterface;
 
 /** Init OpenSSL library multithreading support */

--- a/src/util.h
+++ b/src/util.h
@@ -49,6 +49,7 @@ extern bool fLogTimestamps;
 extern bool fLogTimeMicros;
 extern bool fLogIPs;
 extern std::atomic<bool> fReopenDebugLog;
+extern std::atomic<bool> fActivatingChain; // True while activating the best chain
 extern CTranslationInterface translationInterface;
 
 extern const char *const BITCOIN_CONF_FILENAME;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -36,6 +36,7 @@
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #include "validationinterface.h"
+#include "validation_thread.h"
 #include "versionbits.h"
 #include "warnings.h"
 
@@ -2787,6 +2788,9 @@ bool ActivateBestChain(const Config &config, CValidationState &state,
     // us in the middle of ProcessNewBlock - do not assume pblock is set
     // sanely for performance or correctness!
 
+    if (fActivatingChain)
+        return true;
+    fActivatingChain = true;
     CBlockIndex *pindexMostWork = nullptr;
     CBlockIndex *pindexNewTip = nullptr;
     do {
@@ -2815,8 +2819,10 @@ bool ActivateBestChain(const Config &config, CValidationState &state,
 
                 // Whether we have anything to do at all.
                 if (pindexMostWork == nullptr ||
-                    pindexMostWork == chainActive.Tip())
+                    pindexMostWork == chainActive.Tip()) {
+                    fActivatingChain = false;
                     return true;
+                }
 
                 bool fInvalidFound = false;
                 std::shared_ptr<const CBlock> nullBlockPtr;
@@ -2827,8 +2833,10 @@ bool ActivateBestChain(const Config &config, CValidationState &state,
                                     pindexMostWork->GetBlockHash()
                             ? pblock
                             : nullBlockPtr,
-                        fInvalidFound, connectTrace))
+                        fInvalidFound, connectTrace)) {
+                    fActivatingChain = false;
                     return false;
+                }
 
                 if (fInvalidFound) {
                     // Wipe cache, we may need another branch now.
@@ -2870,9 +2878,11 @@ bool ActivateBestChain(const Config &config, CValidationState &state,
 
     // Write changes periodically to disk, after relay.
     if (!FlushStateToDisk(state, FLUSH_STATE_PERIODIC)) {
+        fActivatingChain = false;
         return false;
     }
 
+    fActivatingChain = false;
     return true;
 }
 
@@ -3697,6 +3707,11 @@ static bool AcceptBlock(const Config &config,
     return true;
 }
 
+void FormBestChain(const Config &config) {
+    CValidationState state;
+    ActivateBestChain(config, state);
+}
+
 bool ProcessNewBlock(const Config &config,
                      const std::shared_ptr<const CBlock> pblock,
                      bool fForceProcessing, bool *fNewBlock) {
@@ -3728,10 +3743,16 @@ bool ProcessNewBlock(const Config &config,
 
     NotifyHeaderTip();
 
-    // Only used to report errors, not invalidity - ignore it
-    CValidationState state;
-    if (!ActivateBestChain(config, state, pblock))
-        return error("%s: ActivateBestChain failed", __func__);
+    // If best header is within 6 blocks from our tip, activate best chain withtin the message handler thread to avoid the 100ms delay,
+    // and to avoid breaking the miner tests.
+    if (fActivatingChain || pindexBestHeader->nChainWork > chainActive.Tip()->nChainWork + GetBlockProof(*chainActive.Tip()) * 6)
+        fActivateChain = true;
+    else {
+        // Only used to report errors, not invalidity - ignore it
+        CValidationState state;
+        if (!ActivateBestChain(config, state, pblock))
+            return error("%s: ActivateBestChain failed", __func__);
+    }
 
     return true;
 }

--- a/src/validation.h
+++ b/src/validation.h
@@ -323,6 +323,7 @@ bool ActivateBestChain(
     const Config &config, CValidationState &state,
     std::shared_ptr<const CBlock> pblock = std::shared_ptr<const CBlock>());
 Amount GetBlockSubsidy(int nHeight, const Consensus::Params &consensusParams);
+void FormBestChain(const Config &config);
 
 /** Guess verification progress (as a fraction between 0.0=genesis and
  * 1.0=current tip). */

--- a/src/validation_thread.cpp
+++ b/src/validation_thread.cpp
@@ -1,0 +1,27 @@
+#include "chainparams.h"
+#include "validation.h"
+#include "validationinterface.h"
+#include "net.h"
+#include "config.h" // For GetConfig();
+
+std::atomic<bool> fActivateChain(true);
+
+void CConnman::ThreadValidation()
+{
+    int nSleep;
+    while (!flagInterruptMsgProc) {
+        if (fActivateChain && !fActivatingChain) {
+            fActivateChain = false;
+            FormBestChain(GetConfig());
+        }
+        if (!pindexBestHeader || pindexBestHeader->nChainWork == chainActive.Tip()->nChainWork)
+            nSleep = 1000;
+        else
+            nSleep = 100;
+        if (!fActivateChain)
+            MilliSleep(nSleep);
+        else
+            nSleep = 0;
+    }
+}
+

--- a/src/validation_thread.h
+++ b/src/validation_thread.h
@@ -1,0 +1,1 @@
+extern std::atomic<bool> fActivateChain; // Set to true to trigger validation thread


### PR DESCRIPTION
Bitcoin Core has for a long time generally ignored messages when Updating the active tip, which usually causes delays in block download during IBD, and also causes it to ignore other nodes and therefore delay their block downloads also. This PR moves the updating of the tip into a separate thread, so that messages can continue to be handled during the update of the tip. Once the tip gets to within 6 blocks from the best block, the update tip moves back into the main thread in order to avoid potential problems with chain forks.