### PR TITLE
workaround boost::variant <= 1.57 doesn't have operator!=

### DIFF
--- a/src/test/cashaddrenc_tests.cpp
+++ b/src/test/cashaddrenc_tests.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(invalid_on_wrong_network) {
 
             std::string encoded = EncodeCashAddr(dst, Params(net));
             CTxDestination decoded = DecodeCashAddr(encoded, Params(otherNet));
-            BOOST_CHECK(decoded != dst);
+            BOOST_CHECK(!(decoded == dst));
             BOOST_CHECK(decoded == invalidDst);
         }
     }
@@ -141,7 +141,7 @@ BOOST_AUTO_TEST_CASE(check_padding) {
         if (i & 0x03) {
             BOOST_CHECK(dst == nodst);
         } else {
-            BOOST_CHECK(dst != nodst);
+            BOOST_CHECK(!(dst == nodst));
         }
     }
 }


### PR DESCRIPTION
While attempting to build bitcoin-abc on CentOS 7, which has boost 1.53, I ran into the compile error given below:

It turns out that boost::variant didn't gain an operator!= operator until 1.58.

This patch allows the test cases to compile with older versions of Boost. The current boost::variant documentation states that these are semantically identical, and all tests pass with this code.

```
In file included from /usr/include/boost/test/unit_test.hpp:19:0,
                 from test/cashaddrenc_tests.cpp:12:
test/cashaddrenc_tests.cpp: In member function ‘void cashaddrenc_tests::invalid_on_wrong_network::test_method()’:
test/cashaddrenc_tests.cpp:83:33: error: no match for ‘operator!=’ (operand types are ‘CTxDestination {aka boost::variant<CNoDestination, CKeyID, CScriptID>}’ and ‘const CTxDestination {aka const boost::variant<CNoDestination, CKeyID, CScriptID>}’)
             BOOST_CHECK(decoded != dst);
                                 ^
```