### PR TITLE
Reduced the minimum fee for relaying a transaction from 1000 to 100 satoshis.

### DIFF
--- a/src/validation.h
+++ b/src/validation.h
@@ -56,7 +56,7 @@ static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */
 static const bool DEFAULT_WHITELISTFORCERELAY = true;
 /** Default for -minrelaytxfee, minimum relay fee for transactions */
-static const Amount DEFAULT_MIN_RELAY_TX_FEE(1000);
+static const Amount DEFAULT_MIN_RELAY_TX_FEE(100);
 //! -maxtxfee default
 static const Amount DEFAULT_TRANSACTION_MAXFEE(COIN / 10);
 //! Discourage users to set fees higher than this amount (in satoshis) per kB


### PR DESCRIPTION
With the increased block size on the Bitcoin Cash network, it seems we could drop the minimum transaction fee for relaying transactions to encourage use.