### PR TITLE
Update Boost build instructions

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -204,7 +204,7 @@ If you need to build Boost yourself:
 
 	sudo su
 	./bootstrap.sh
-	./bjam install
+	./b2 install
 
 
 Security


### PR DESCRIPTION
A quick search or attempt will reveal `./b2 install` is now the way to install as opposed to using `bjam`.