### PR TITLE
policy: Allow nodes to override default fee policy with a free transaction policy

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1468,7 +1468,7 @@ bool AppInitParameterInteraction(Config &config) {
     if (IsArgSet("-minrelaytxfee")) {
         Amount n(0);
         auto parsed = ParseMoney(GetArg("-minrelaytxfee", ""), n);
-        if (!parsed || Amount(0) == n)
+        if (!parsed)
             return InitError(
                 AmountErrMsg("minrelaytxfee", GetArg("-minrelaytxfee", "")));
         // High fee check is done afterward in CWallet::ParameterInteraction()

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4286,7 +4286,7 @@ bool CWallet::ParameterInteraction() {
     if (IsArgSet("-mintxfee")) {
         Amount n(0);
         auto parsed = ParseMoney(GetArg("-mintxfee", ""), n);
-        if (!parsed || Amount(0) == n) {
+        if (!parsed) {
             return InitError(AmountErrMsg("mintxfee", GetArg("-mintxfee", "")));
         }
 


### PR DESCRIPTION
This patch allows node operators to override the default fee policy with a free transaction policy via command line args `-minrelaytxfee` and `-mintxfee`.

For example, to unconditionally accept zero-fee transactions into your node's mempool and to relay zero-fee transactions, start your node with: `-minrelaytxfee=0.00000000`

Some nodes currently have a zero-fee policy. But, there are not enough of them to make it easy to get to enough miners to be considered for inclusion into a block.

Related commit: fa4bfb48193a03d99d1dfdfd1e67b613293755bf

And for fun:

> "... and there will probably always be nodes willing to process transactions for free."
> 
> Satoshi Nakamoto

http://satoshi.nakamotoinstitute.org/emails/cryptography/16/#selection-129.0-137.16