### PR TITLE
Adaptive block size

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -15,7 +15,8 @@ static const uint64_t MAX_TX_SIZE = ONE_MEGABYTE;
 /** The maximum allowed size for a block, before the UAHF */
 static const uint64_t LEGACY_MAX_BLOCK_SIZE = ONE_MEGABYTE;
 /** Default setting for maximum allowed size for a block, in bytes */
-static const uint64_t DEFAULT_MAX_BLOCK_SIZE = 8 * ONE_MEGABYTE;
+/* (network rule) This limit doesn't make sense considering the BCH philosophy */
+static const uint64_t DEFAULT_MAX_BLOCK_SIZE = UINT64_MAX;
 /** The maximum allowed number of signature check operations per MB in a block
  * (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_PER_MB = 20000;

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -15,8 +15,12 @@ static const uint64_t MAX_TX_SIZE = ONE_MEGABYTE;
 /** The maximum allowed size for a block, before the UAHF */
 static const uint64_t LEGACY_MAX_BLOCK_SIZE = ONE_MEGABYTE;
 /** Default setting for maximum allowed size for a block, in bytes */
-/* (network rule) This limit doesn't make sense considering the BCH philosophy */
-static const uint64_t DEFAULT_MAX_BLOCK_SIZE = UINT64_MAX;
+/* (network rule)This limit doesn't make sense considering the BCH philosophy */
+/* 2GB is a physical limit on 32bit kernels                                   */
+/* because BCH still has a 32bit version available in 2018					  */
+/* 512 MB is a more conservative value less prone to memory allocation errors */
+/* virtually ilimited @ 2018                                                  */
+static const uint64_t DEFAULT_MAX_BLOCK_SIZE = 512 * ONE_MEGABYTE;
 /** The maximum allowed number of signature check operations per MB in a block
  * (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_PER_MB = 20000;


### PR DESCRIPTION
Given the Bitcoin Cash philosophy, BCH is a peer-to-peer cash system that is intended to serve the users with cheap transaction fees, through a full on-chain transaction blockchain ledger.

There are some features planned for the "Bitcoin ABC - Medium Term Development Plan", and one of them is the "Increase default block-size limit, and move towards adaptive block size limit".

Given the feedback of @ProfFaustus and other dedicated BCH supporters on Twitter, miners are the full nodes and both should be together. These systems will gradually converge into high-end home mining setups and/or, more professionally, data-centers. Most of them are already in these type of setups, therefore nothing to worry about. Users with moderate computational power like laptops, smartphones, etc ... should use SPV wallet software, delivering to miners the enforcement of BCH blockchain rules.

The gradual increase of this limit through hard-forks is useless and pointless (given the BCH system topology) and will introduce unnecessary entropy and forks on the system without any added-value. HF only to increase the limit everytime is needed, is the same thing than having no limit at all, considering also the high-end mining systems that are being used today and in the future.
 
The high fee prices registered on BTC is a usual phenomenon easily described in the [Law of supply and demand](https://www.investopedia.com/university/economics/economics3.asp), the demand surpasses the supply and therefore only the most profitable transactions are included in blocks. This phenomenon is transversal to any blockchain that has a max block size limit, and its adoption reaches it.

Considering the Law of supply and demand, BCH will only be immune to this phenomenon if its blocks could process all the mempool transactions in time for the next block.

Removing the limit will put miners in the following dilemma:

- To include the maximum number of transactions they spend computational power to validate them;
- The more transactions they include in the block, more time they spend validating them;
- This time window gives time to another miner, broadcast a valid block in the network, losing then the opportunity to broadcast its own block;
- The increased size also takes longer to transmit on the network between peers, and in the meantime, those peers could also have accepted other competing block, so the miner has a lower probability to register its block on the blockchain.

Miners should balance some factors, in order to be competitive against other miners:

- Mining puzzle (Hash rate)
- Validation time
- Total fee amount
- Propagation

All these factors balanced together, achieve the correct size of blocks giving the current (at the given time) blockchain use, technological evolution level, network speed and cap, etc ...

Achieving by this method the desired feature: "adaptive block size"

The prevention of spam attacks is easily prevented by enforcing a minimum transaction fee (that is already being enforced by BCH miners) and by applying multiple well-known strategies in their home/professional datacenters.

Balancing these factors and removing this limit doesn't guarantee that all transaction are processed in time of the next block because the adoption could reach a hard physical and computational limit. But it will guarantee that it will be the fastest strategy to achieve the lowest fees and the smaller confirmation times at that precise moment.

Conclusion: Blocks will be capped by game-theory.

Best regards,
  Pedro Simões.

****** Update ******

The previous commit introduced/revealed some bugs in the rest of the system.
The maximum value allowed by tests is 9223372036854775807 bytes, the reason for this limit needs a deeper investigation.
However, this value crashes the system in some block creation function, therefore lower limits were tested.
After multiple values, 4GB, 2GB, 1GB and lastly 512MB,
The maximum allowed value without any crash on CI/unit tests is 512MB (still pretty high, virtually unlimited @2018)
The build and tests were made on a Ubuntu LTS 16.04 32bit machine, with the lower specs needed to build/run the 32bit BCH release.
It's expectable that some nodes could struggle with some memory allocation issues when dealing with bigger blocks.

Conclusion: Memory allocations should be reviewed in future iterations.






 