### PR TITLE
Calculated nBits will be replaced by the following GetNextWorkRequired(.) function

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -49,22 +49,13 @@ static const int MAX_COINBASE_SCRIPTSIG_SIZE = 100;
 uint64_t nLastBlockTx = 0;
 uint64_t nLastBlockSize = 0;
 
-int64_t UpdateTime(CBlockHeader *pblock, const Config &config,
-                   const CBlockIndex *pindexPrev) {
+int64_t UpdateTime(CBlockHeader *pblock, const CBlockIndex *pindexPrev) {
     int64_t nOldTime = pblock->nTime;
     int64_t nNewTime =
         std::max(pindexPrev->GetMedianTimePast() + 1, GetAdjustedTime());
 
     if (nOldTime < nNewTime) {
         pblock->nTime = nNewTime;
-    }
-
-    const Consensus::Params &consensusParams =
-        config.GetChainParams().GetConsensus();
-
-    // Updating time can change work required on testnet:
-    if (consensusParams.fPowAllowMinDifficultyBlocks) {
-        pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, config);
     }
 
     return nNewTime - nOldTime;
@@ -207,7 +198,7 @@ BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn) {
 
     // Fill in header.
     pblock->hashPrevBlock = pindexPrev->GetBlockHash();
-    UpdateTime(pblock, *config, pindexPrev);
+    UpdateTime(pblock, pindexPrev);
     pblock->nBits = GetNextWorkRequired(pindexPrev, pblock, *config);
     pblock->nNonce = 0;
     pblocktemplate->vTxSigOpsCount[0] =

--- a/src/miner.h
+++ b/src/miner.h
@@ -213,6 +213,5 @@ private:
 void IncrementExtraNonce(const Config &config, CBlock *pblock,
                          const CBlockIndex *pindexPrev,
                          unsigned int &nExtraNonce);
-int64_t UpdateTime(CBlockHeader *pblock, const Config &config,
-                   const CBlockIndex *pindexPrev);
+int64_t UpdateTime(CBlockHeader *pblock, const CBlockIndex *pindexPrev);
 #endif // BITCOIN_MINER_H

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -642,7 +642,7 @@ static UniValue getblocktemplate(const Config &config,
         config.GetChainParams().GetConsensus();
 
     // Update nTime
-    UpdateTime(pblock, config, pindexPrev);
+    UpdateTime(pblock, pindexPrev);
     pblock->nNonce = 0;
 
     UniValue aCaps(UniValue::VARR);


### PR DESCRIPTION
#### There are two reasons to remove the code(as you see):

- The calculated nBits will be replaced by the following GetNextWorkRequired(.) function. So calculating difficulty(nBits) in UpdateTime() function is meaningless. The main chain does not matter. But testnet will exec twice.
- UpdateTime() function should remain single role for updating timestamp item of block.
