### PR TITLE
Restore symlink support removed from Core client

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -600,10 +600,9 @@ bool CWallet::Verify(const CChainParams &chainParams) {
 
         fs::path wallet_path = fs::absolute(walletFile, GetDataDir());
 
-        if (fs::exists(wallet_path) && (!fs::is_regular_file(wallet_path) ||
-                                        fs::is_symlink(wallet_path))) {
+        if (fs::exists(wallet_path)) {
             return InitError(strprintf(_("Error loading wallet %s. -wallet "
-                                         "filename must be a regular file."),
+                                         "filename must be an existing file."),
                                        walletFile));
         }
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -600,7 +600,7 @@ bool CWallet::Verify(const CChainParams &chainParams) {
 
         fs::path wallet_path = fs::absolute(walletFile, GetDataDir());
 
-        if (fs::exists(wallet_path)) {
+        if (!fs::exists(wallet_path)) {
             return InitError(strprintf(_("Error loading wallet %s. -wallet "
                                          "filename must be an existing file."),
                                        walletFile));

--- a/test/functional/multiwallet.py
+++ b/test/functional/multiwallet.py
@@ -30,15 +30,7 @@ class MultiWalletTest(BitcoinTestFramework):
         # should not initialize if wallet file is a directory
         os.mkdir(os.path.join(self.options.tmpdir, 'node0', 'regtest', 'w11'))
         self.assert_start_raises_init_error(
-            0, ['-wallet=w11'], 'Error loading wallet w11. -wallet filename must be a regular file.')
-
-        # should not initialize if wallet file is a symlink
-        wallet_dir = os.path.abspath(os.path.join(
-            self.options.tmpdir, 'node0', 'regtest'))
-        os.symlink(os.path.join(wallet_dir, 'w1'),
-                   os.path.join(wallet_dir, 'w12'))
-        self.assert_start_raises_init_error(
-            0, ['-wallet=w12'], 'Error loading wallet w12. -wallet filename must be a regular file.')
+            0, ['-wallet=w11'], 'Error loading wallet w11. -wallet filename must be an existing file.')
 
         self.start_node(0, self.extra_args[0])
 


### PR DESCRIPTION
Also see related issue #201 

Since at least version 0.17 or version 0.17.1 of Bitcoin ABC, it is no longer possible to use symlinks as wallet files in Bitcoin-ABC client.

In general, symlinking is a 30 year old technology, widely established in both business and home usage.

There are 3 issues at play here:
1. On the original commit discussion, it was claimed that having a symlinked wallet file can result in filesystem (and wallet file) corruption. No proof or real-life examples of such claims have been given
2. I have been using symlinks-as-wallet-files for **years** now, it dates back to 2011. Also there are many more people in the net claiming so. See linked issues in #201 
3. Newbie users don't use symlinks, it can be assumed that users knows what he is doing when he is using symlink (only power users do so anyway)

Also having wallet file as symlink enables an additional security layer - wallet file can be on a separate encrypted medium (such as Truecrypt virtual drive), encrypted using different keys. It also allows for wallet management/scripting. One can switch wallets using a script which just switches symlinks to a different location.

Therefore I see absolutely no reason to forbid people who know what they are doing from using symlinks.