### PR TITLE
Fixes broken link to disclosure policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,4 +213,4 @@ author must contain its license header with the original author(s) and source.
 Disclosure Policy
 -----------------
 
-See [DISCLOSURE_POLICY](DISCLOSURE_POLICY).
+See [DISCLOSURE_POLICY](DISCLOSURE_POLICY.md).


### PR DESCRIPTION
Current link to disclosure policy is a broken link. This fixes the link.