### PR TITLE
Make -enableminerfund=0 work as expected

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -148,7 +148,8 @@ public:
         };
 
         // The miner fund is enabled by default on mainnet.
-        consensus.enableMinerFund = true;
+        // NOPE --fireduck
+        consensus.enableMinerFund = false;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork =

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -148,8 +148,7 @@ public:
         };
 
         // The miner fund is enabled by default on mainnet.
-        // NOPE --fireduck
-        consensus.enableMinerFund = false;
+        consensus.enableMinerFund = gArgs.GetBoolArg("-enableminerfund", true);
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork =

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -210,7 +210,12 @@ public:
     explicit VersionBitsConditionChecker(Consensus::DeploymentPos id_)
         : id(id_) {}
     uint32_t Mask(const Consensus::Params &params) const {
-        return uint32_t(1) << params.vDeployments[id].bit;
+        if (params.enableMinerFund) {
+          return uint32_t(1) << params.vDeployments[id].bit;
+        }
+        else {
+          return 0;
+        }
     }
 };
 


### PR DESCRIPTION
The results of changing this parameter will now change the version bits in getblocktemplate, as expected.

