### PR TITLE
sendrawtransaction - maxfeerate parameter can be numeric or string

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -923,7 +923,7 @@ static UniValue sendrawtransaction(const Config &config,
                            "Second argument must be numeric (maxfeerate) and "
                            "no longer supports a boolean. To allow a "
                            "transaction with high fees, set maxfeerate to 0.");
-    } else if (request.params[1].isNum()) {
+    } else if (request.params[1].isNum() || request.params[1].isStr()) {
         size_t sz = tx->GetTotalSize();
         CFeeRate fr(AmountFromValue(request.params[1]));
         max_raw_tx_fee = fr.GetFee(sz);


### PR DESCRIPTION
When I pass a string as the second argument for rpc command sendrawtransaction, I'm getting the next error **"second argument (maxfeerate) must be numeric"**, even if the documentation says this argument can be numeric or string.

Resolves #394 