### PR TITLE
[ecashaddrjs] Fix types for `isValidCashAddress`

### DIFF
--- a/modules/ecashaddrjs/src/cashaddr.d.ts
+++ b/modules/ecashaddrjs/src/cashaddr.d.ts
@@ -32,7 +32,7 @@ declare module 'ecashaddrjs' {
 
     export function isValidCashAddress(
         cashaddress: string,
-        optionalPrefix: string,
+        optionalPrefix?: string | false,
     ): boolean;
 
     export function toLegacy(cashaddress: string): string;


### PR DESCRIPTION
Fix type definition for `optionalPrefix` param in `isValidCashAddress` method